### PR TITLE
feat: `matrix-admin` and e2e tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# Commune
+#
+# The shared secret is used to authenticate the registration requests.
+#
+# This is explicitly passed here for development purposes, it should match the
+# same as on `fixtures/synapse/homeserver.yaml` for CI.
+COMMUNE_REGISTRATION_SHARED_SECRET='m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B'
+
 # Matrix Client
 MATRIX_HOST=http://localhost:8008
 MATRIX_ADMIN_TOKEN=secret

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'cargo'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - "**"
+      - "!/*.md"
+      - "!/**.md"
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Check clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Unit Tests
+        run: cargo test -p matrix
+
+      - name: Install Just
+        uses: extractions/setup-just@v1
+
+      - name: Prepare Data for Tests
+        run: |
+          cp -R ./crates/test/fixtures/synapse ./docker/synapse
+          docker compose up -d
+
+      - name: E2E Tests
+        run: cargo test -p test -- --test-threads=1

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+    "crates/matrix",
+    "crates/test"
+]
+resolver = "1"
+
+[workspace.dependencies]
+serde = "1.0.192"
+url = { version = "2.4.1", features = ["serde"] }

--- a/Justfile
+++ b/Justfile
@@ -27,3 +27,7 @@ stop:
 clear: stop
   docker compose rm --all --force --volumes --stop
   docker volume rm commune_synapse_database || true
+
+# Runs all the tests from the `test` package. Optionally runs a single one if name pattern is provided
+e2e *args='':
+  cargo test --package test -- --test-threads=1 $1

--- a/crates/matrix/Cargo.toml
+++ b/crates/matrix/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "matrix"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.75"
+async-trait = "0.1.74"
+hex = "0.4.3"
+hmac = "0.12.1"
+matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk.git", rev = "e43a25a" }
+reqwest = { version = "0.11.22", features = ["json"] }
+serde_path_to_error = "0.1.14"
+serde_qs = "0.12.0"
+sha1 = "0.10.6"
+
+# Workspace Dependencies
+serde = { workspace = true }
+url = { workspace = true }

--- a/crates/matrix/src/admin/client.rs
+++ b/crates/matrix/src/admin/client.rs
@@ -1,0 +1,137 @@
+use std::ops::Deref;
+use std::str::from_utf8;
+
+use anyhow::{bail, Result};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::{Client as HttpClient, Response};
+use serde::Serialize;
+use url::Url;
+
+pub struct Client {
+    client: HttpClient,
+    base_url: Url,
+    token: Option<String>,
+}
+
+impl Client {
+    pub fn new<S: AsRef<str>>(url: S) -> Result<Self> {
+        let url = Url::parse(url.as_ref())?;
+
+        Ok(Self {
+            client: HttpClient::new(),
+            base_url: url,
+            token: None,
+        })
+    }
+
+    /// Sets the token to be used for authentication with the server.
+    pub fn set_token(&mut self, token: impl Into<String>) -> Result<()> {
+        let token = token.into();
+
+        if token.is_empty() {
+            self.token = None;
+            bail!("Token cannot be empty");
+        }
+
+        self.token = Some(token);
+        Ok(())
+    }
+
+    pub async fn get(&self, path: impl AsRef<str>) -> Result<Response> {
+        let url = self.build_url(path)?;
+        let headers = self.build_headers()?;
+        let response = self.client.get(url).headers(headers).send().await?;
+
+        Ok(response)
+    }
+
+    pub async fn get_query(
+        &self,
+        path: impl AsRef<str>,
+        params: impl Serialize,
+    ) -> Result<Response> {
+        let url = self.build_url_with_params(path, params)?;
+        let headers = self.build_headers()?;
+        let response = self.client.get(url).headers(headers).send().await?;
+
+        Ok(response)
+    }
+
+    pub async fn post_json<T>(&self, path: impl AsRef<str>, body: &T) -> Result<Response>
+    where
+        T: Serialize,
+    {
+        let url = self.build_url(path)?;
+        let headers = self.build_headers()?;
+        let resp = self
+            .client
+            .post(url)
+            .json(body)
+            .headers(headers)
+            .send()
+            .await?;
+
+        Ok(resp)
+    }
+
+    pub async fn put_json<T>(&self, path: impl AsRef<str>, body: &T) -> Result<Response>
+    where
+        T: Serialize,
+    {
+        let url = self.build_url(path)?;
+        let headers = self.build_headers()?;
+        let resp = self
+            .client
+            .put(url)
+            .json(body)
+            .headers(headers)
+            .send()
+            .await?;
+
+        Ok(resp)
+    }
+
+    fn build_headers(&self) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+
+        if let Some(token) = &self.token {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", token))?,
+            );
+        }
+
+        Ok(headers)
+    }
+
+    #[inline]
+    fn build_url(&self, path: impl AsRef<str>) -> Result<Url> {
+        let mut next = self.base_url.clone();
+
+        next.set_path(path.as_ref());
+
+        Ok(next)
+    }
+
+    fn build_url_with_params(&self, path: impl AsRef<str>, params: impl Serialize) -> Result<Url> {
+        let mut url = self.build_url(path)?;
+        let mut buff = Vec::new();
+        let qs_ser = &mut serde_qs::Serializer::new(&mut buff);
+
+        serde_path_to_error::serialize(&params, qs_ser)?;
+
+        let params = from_utf8(buff.as_slice())?.to_string();
+
+        url.set_query(Some(&params));
+
+        Ok(url)
+    }
+}
+
+impl Deref for Client {
+    type Target = HttpClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}

--- a/crates/matrix/src/admin/mod.rs
+++ b/crates/matrix/src/admin/mod.rs
@@ -1,0 +1,4 @@
+pub mod client;
+pub mod resources;
+
+pub use client::Client;

--- a/crates/matrix/src/admin/resources/mod.rs
+++ b/crates/matrix/src/admin/resources/mod.rs
@@ -1,0 +1,1 @@
+pub mod token;

--- a/crates/matrix/src/admin/resources/token/mod.rs
+++ b/crates/matrix/src/admin/resources/token/mod.rs
@@ -1,0 +1,1 @@
+pub mod shared_secret;

--- a/crates/matrix/src/admin/resources/token/shared_secret.rs
+++ b/crates/matrix/src/admin/resources/token/shared_secret.rs
@@ -1,0 +1,161 @@
+//! [Shared-Secret Registration API](https://matrix-org.github.io/synapse/latest/admin_api/register_api.html#)
+//!
+//! # Important
+//!
+//! This API is disabled when MSC3861 is enabled. See [#15582](https://github.com/matrix-org/synapse/pull/15582)
+//!
+//! This API allows for the creation of users in an administrative and
+//! non-interactive way. This is generally used for bootstrapping a Synapse
+//! instance with administrator accounts.
+//!
+//! To authenticate yourself to the server, you will need both the shared secret
+//! (registration_shared_secret in the homeserver configuration), and a one-time
+//! nonce. If the registration shared secret is not configured, this API is not
+//! enabled.
+
+use anyhow::Result;
+use hex;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha1::Sha1;
+
+use crate::admin::Client;
+
+type HmacSha1 = Hmac<Sha1>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Nonce {
+    pub nonce: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SharedSecretRegistrationDto {
+    pub nonce: String,
+    pub username: String,
+    pub displayname: Option<String>,
+    pub password: String,
+    pub admin: bool,
+    /// The MAC is the hex digest output of the HMAC-SHA1 algorithm, with the
+    /// key being the shared secret and the content being the nonce, user,
+    /// password, either the string "admin" or "notadmin", and optionally the
+    /// user_type each separated by NULs.
+    pub mac: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SharedSecretRegistration {
+    pub access_token: String,
+    pub user_id: String,
+    pub home_server: String,
+    pub device_id: String,
+}
+
+impl SharedSecretRegistration {
+    /// Fetches the `Nonce` from the server.
+    ///
+    /// Refer: https://matrix-org.github.io/synapse/latest/admin_api/register_api.html#shared-secret-registration
+    pub async fn get_nonce(client: &Client) -> Result<Nonce> {
+        let resp = client.get("/_synapse/admin/v1/register").await?;
+
+        Ok(resp.json().await?)
+    }
+
+    /// Creates the [`SharedSecretRegistration`] instance.
+    ///
+    /// Refer: https://matrix-org.github.io/synapse/latest/admin_api/register_api.html#shared-secret-registration
+    pub async fn create(client: &Client, dto: SharedSecretRegistrationDto) -> Result<Self> {
+        let resp = client
+            .post_json("/_synapse/admin/v1/register", &dto)
+            .await?;
+
+        Ok(resp.json().await?)
+    }
+
+    /// Generates the MAC.
+    ///
+    /// # Inspiration
+    ///
+    /// This implementation is inspired by the following Python code from the
+    /// Synapse documentation on `Shared-Secret Registration`.
+    ///
+    /// ```python
+    /// import hmac, hashlib
+    ///
+    /// def generate_mac(nonce, user, password, admin=False, user_type=None):
+    ///
+    ///     mac = hmac.new(
+    ///       key=shared_secret,
+    ///       digestmod=hashlib.sha1,
+    ///     )
+    ///
+    ///     mac.update(nonce.encode('utf8'))
+    ///     mac.update(b"\x00")
+    ///     mac.update(user.encode('utf8'))
+    ///     mac.update(b"\x00")
+    ///     mac.update(password.encode('utf8'))
+    ///     mac.update(b"\x00")
+    ///     mac.update(b"admin" if admin else b"notadmin")
+    ///     if user_type:
+    ///         mac.update(b"\x00")
+    ///         mac.update(user_type.encode('utf8'))
+    ///
+    ///     return mac.hexdigest()
+    /// ```
+    /// [Source](https://matrix-org.github.io/synapse/latest/admin_api/register_api.html#shared-secret-registration)
+    pub fn generate_mac<S: AsRef<str>>(
+        shared_secret: S,
+        nonce: S,
+        user: S,
+        password: S,
+        admin: bool,
+        user_type: Option<S>,
+    ) -> Result<String> {
+        let mut mac = HmacSha1::new_from_slice(shared_secret.as_ref().as_bytes())?;
+
+        mac.update(nonce.as_ref().as_bytes());
+        mac.update(b"\x00");
+
+        mac.update(user.as_ref().as_bytes());
+        mac.update(b"\x00");
+
+        mac.update(password.as_ref().as_bytes());
+        mac.update(b"\x00");
+
+        if admin {
+            mac.update("admin".as_bytes());
+        } else {
+            mac.update("notadmin".as_bytes());
+        }
+
+        if let Some(user_type) = user_type {
+            mac.update(b"\x00");
+            mac.update(user_type.as_ref().as_bytes());
+        }
+
+        let result = mac.finalize();
+        let code_bytes = result.into_bytes();
+
+        Ok(hex::encode(code_bytes))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SharedSecretRegistration;
+
+    #[test]
+    fn generates_mac_accordingly() {
+        let want = "c272fb1c287c795ff5ce238c4dba57cf95db5eff";
+        let have = SharedSecretRegistration::generate_mac(
+            "m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B",
+            "1234567890",
+            "groot",
+            "imroot!1234",
+            true,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(have, want);
+    }
+}

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -1,0 +1,18 @@
+//! Crate to centralize all Matrix dependencies.
+//!
+//! Reexports `matrix_sdk` and provides implementations on Matrix Admin API.
+
+/// Implementation on the Administrator API of Matrix
+///
+/// Refer: https://matrix-org.github.io/synapse/latest/usage/administration/index.html
+pub mod admin;
+
+/// The official Matrix Rust SDK.
+///
+/// # Project State
+///
+/// As of today this SDK is still in beta and is not yet ready for production,
+/// so we make use of the repo at a specific commit.
+///
+/// Refer: https://github.com/matrix-org/matrix-rust-sdk
+pub use matrix_sdk as sdk;

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "test"
+path = "src/lib.rs"
+
+[dependencies]
+dotenv = "0.15.0"
+tokio = { version = "1.34.0", features = ["rt", "rt-multi-thread", "macros"] }
+
+# Workspace Dependencies
+serde = { workspace = true }
+url = { workspace = true }
+
+# Local Dependencies
+matrix = { path = "../matrix" }

--- a/crates/test/fixtures/synapse/homeserver.yaml
+++ b/crates/test/fixtures/synapse/homeserver.yaml
@@ -1,0 +1,37 @@
+# Configuration file for Synapse.
+#
+# This is a YAML file: see [1] for a quick introduction. Note in particular
+# that *indentation is important*: all the elements of a list or dictionary
+# should have the same indentation.
+#
+# [1] https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
+#
+# For more information on how to configure Synapse, including a complete accounting of
+# each option, go to docs/usage/configuration/config_documentation.md or
+# https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html
+server_name: "matrix.localhost"
+pid_file: /data/homeserver.pid
+listeners:
+  - port: 8008
+    tls: false
+    type: http
+    x_forwarded: true
+    resources:
+      - names: [client, federation]
+        compress: false
+database:
+  name: sqlite3
+  args:
+    database: /data/homeserver.db
+log_config: "/data/matrix.localhost.log.config"
+media_store_path: /data/media_store
+registration_shared_secret: "m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B"
+report_stats: true
+macaroon_secret_key: "XND.g+P_7wz.Yx:i6js.Eh;=jG*#uWBIe;X2OoX78^E,LVJ;8c"
+form_secret: "pS7pR@AFJD~BtUAqH^ku5Kenz1X^Hol0E_+xhwvohOrkx;sMoO"
+signing_key_path: "/data/matrix.localhost.signing.key"
+trusted_key_servers:
+  - server_name: "matrix.org"
+
+
+# vim:ft=yaml

--- a/crates/test/fixtures/synapse/matrix.localhost.log.config
+++ b/crates/test/fixtures/synapse/matrix.localhost.log.config
@@ -1,0 +1,39 @@
+version: 1
+
+formatters:
+  precise:
+    
+    format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    
+
+handlers:
+
+
+  console:
+    class: logging.StreamHandler
+    formatter: precise
+
+loggers:
+    # This is just here so we can leave `loggers` in the config regardless of whether
+    # we configure other loggers below (avoid empty yaml dict error).
+    _placeholder:
+        level: "INFO"
+
+    
+    
+    synapse.storage.SQL:
+        # beware: increasing this to DEBUG will make synapse log sensitive
+        # information such as access tokens.
+        level: INFO
+    
+
+    
+
+root:
+    level: INFO
+
+
+    handlers: [console]
+
+
+disable_existing_loggers: false

--- a/crates/test/fixtures/synapse/matrix.localhost.signing.key
+++ b/crates/test/fixtures/synapse/matrix.localhost.signing.key
@@ -1,0 +1,1 @@
+ed25519 a_VKUD FXu3HoEKJdiMh1e+3dW8kO/P8ldSdNzdV+/vg9wdowE

--- a/crates/test/src/environment.rs
+++ b/crates/test/src/environment.rs
@@ -1,0 +1,28 @@
+use std::env::var;
+
+use matrix::admin::Client;
+
+const COMMUNE_REGISTRATION_SHARED_SECRET: &str = "COMMUNE_REGISTRATION_SHARED_SECRET";
+
+pub struct Environment {
+    pub client: Client,
+    pub registration_shared_secret: String,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        dotenv::dotenv().ok();
+
+        let client = Client::new("http://localhost:8008").unwrap();
+        let registration_shared_secret = Self::env_var(COMMUNE_REGISTRATION_SHARED_SECRET);
+
+        Self {
+            client,
+            registration_shared_secret,
+        }
+    }
+
+    pub fn env_var(name: &str) -> String {
+        var(name).unwrap_or_else(|_| panic!("Missing {name} environment variable"))
+    }
+}

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(test)]
+mod environment;
+
+#[cfg(test)]
+mod matrix;

--- a/crates/test/src/matrix/mod.rs
+++ b/crates/test/src/matrix/mod.rs
@@ -1,0 +1,1 @@
+mod shared_token_registration;

--- a/crates/test/src/matrix/shared_token_registration.rs
+++ b/crates/test/src/matrix/shared_token_registration.rs
@@ -1,0 +1,39 @@
+use matrix::admin::resources::token::shared_secret::{
+    SharedSecretRegistration, SharedSecretRegistrationDto,
+};
+
+use crate::environment::Environment;
+
+#[tokio::test]
+async fn creates_user_using_shared_secret() {
+    let env = Environment::new();
+    let nonce = SharedSecretRegistration::get_nonce(&env.client)
+        .await
+        .unwrap()
+        .nonce;
+    let mac = SharedSecretRegistration::generate_mac(
+        env.registration_shared_secret,
+        nonce.clone(),
+        "steve".into(),
+        "verysecure".into(),
+        true,
+        None,
+    )
+    .unwrap();
+    let registration = SharedSecretRegistration::create(
+        &env.client,
+        SharedSecretRegistrationDto {
+            nonce,
+            username: "steve".into(),
+            displayname: Some("steve".into()),
+            password: "verysecure".into(),
+            admin: true,
+            mac,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(!registration.access_token.is_empty());
+    assert!(!registration.user_id.is_empty());
+}

--- a/fixtures/generate_mac.py
+++ b/fixtures/generate_mac.py
@@ -1,0 +1,32 @@
+import hmac, hashlib
+
+def generate_mac(nonce, user, password, admin=False, user_type=None):
+
+    mac = hmac.new(
+      key=b"m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B",
+      digestmod=hashlib.sha1,
+    )
+
+    mac.update(nonce.encode('utf8'))
+    mac.update(b"\x00")
+    mac.update(user.encode('utf8'))
+    mac.update(b"\x00")
+    mac.update(password.encode('utf8'))
+    mac.update(b"\x00")
+    mac.update(b"admin" if admin else b"notadmin")
+    if user_type:
+        mac.update(b"\x00")
+        mac.update(user_type.encode('utf8'))
+
+    return mac.hexdigest()
+
+if __name__ == "__main__":
+  mac = generate_mac(
+    nonce="1234567890",
+    user="groot",
+    password="imroot!1234",
+    admin=True,
+    user_type=None
+  )
+
+  print(mac)

--- a/fixtures/synapse/homeserver.yaml
+++ b/fixtures/synapse/homeserver.yaml
@@ -1,0 +1,45 @@
+# Configuration file for Synapse.
+#
+# This is a YAML file: see [1] for a quick introduction. Note in particular
+# that *indentation is important*: all the elements of a list or dictionary
+# should have the same indentation.
+#
+# [1] https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
+#
+# For more information on how to configure Synapse, including a complete accounting of
+# each option, go to docs/usage/configuration/config_documentation.md or
+# https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html
+server_name: "matrix.localhost"
+pid_file: /data/homeserver.pid
+listeners:
+  - port: 8008
+    tls: false
+    type: http
+    x_forwarded: true
+    resources:
+      - names: [client, federation]
+        compress: false
+database:
+  name: psycopg2
+  txn_limit: 10000
+  allow_unsafe_locale: true
+  args:
+    user: synapse_user
+    password: secretpassword
+    database: synapse
+    host: synapse_database
+    port: 5432
+    cp_min: 5
+    cp_max: 10
+log_config: "/data/matrix.localhost.log.config"
+media_store_path: /data/media_store
+registration_shared_secret: "m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B"
+report_stats: true
+macaroon_secret_key: "XND.g+P_7wz.Yx:i6js.Eh;=jG*#uWBIe;X2OoX78^E,LVJ;8c"
+form_secret: "pS7pR@AFJD~BtUAqH^ku5Kenz1X^Hol0E_+xhwvohOrkx;sMoO"
+signing_key_path: "/data/matrix.localhost.signing.key"
+trusted_key_servers:
+  - server_name: "matrix.org"
+
+
+# vim:ft=yaml

--- a/fixtures/synapse/matrix.localhost.log.config
+++ b/fixtures/synapse/matrix.localhost.log.config
@@ -1,0 +1,39 @@
+version: 1
+
+formatters:
+  precise:
+    
+    format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    
+
+handlers:
+
+
+  console:
+    class: logging.StreamHandler
+    formatter: precise
+
+loggers:
+    # This is just here so we can leave `loggers` in the config regardless of whether
+    # we configure other loggers below (avoid empty yaml dict error).
+    _placeholder:
+        level: "INFO"
+
+    
+    
+    synapse.storage.SQL:
+        # beware: increasing this to DEBUG will make synapse log sensitive
+        # information such as access tokens.
+        level: INFO
+    
+
+    
+
+root:
+    level: INFO
+
+
+    handlers: [console]
+
+
+disable_existing_loggers: false

--- a/fixtures/synapse/matrix.localhost.signing.key
+++ b/fixtures/synapse/matrix.localhost.signing.key
@@ -1,0 +1,1 @@
+ed25519 a_VKUD FXu3HoEKJdiMh1e+3dW8kO/P8ldSdNzdV+/vg9wdowE


### PR DESCRIPTION
Introduce Matrix Admin Client and re-exports official Matrix SDK.

Also provides a crate for E2E testing and different fixtures for use cases on local and
CI.

- Fixtures under `/fixtures/` are intended for development purposes.
- Fixtures under `/crates/test/fixtures` are intended for CI purposes.

## Why?

- On CI SQLite is used to easily re-create database and clear state. (Still WIP)
- On development we want to have PostgreSQL for a long-lived version.
